### PR TITLE
Add full-featured flashcards module

### DIFF
--- a/flashcards.html
+++ b/flashcards.html
@@ -3,58 +3,92 @@
 <head>
 <meta charset="UTF-8">
 <meta name="viewport" content="width=device-width,initial-scale=1">
-<title>Flashcards</title>
+<title>Number Flashcards</title>
 <style>
-body{margin:0;font-family:Arial,Helvetica,sans-serif;background:#f0f9ff;height:100vh;display:flex;flex-direction:column;align-items:center;justify-content:center;overflow:hidden}
-#card{width:200px;height:300px;perspective:1000px}
-#card .inner{position:relative;width:100%;height:100%;transform-style:preserve-3d;transition:transform .6s}
-#card.flip .inner{transform:rotateY(180deg)}
-.face{position:absolute;width:100%;height:100%;border-radius:10px;backface-visibility:hidden;border:2px solid #1e88e5;display:flex;align-items:center;justify-content:center;background:#fff}
+*{box-sizing:border-box}
+body{margin:0;font-family:Arial,Helvetica,sans-serif;background:#f0f9ff;display:flex;flex-direction:column;align-items:center;min-height:100vh}
+#container{width:100%;max-width:480px;flex:1;display:flex;flex-direction:column;align-items:center;justify-content:center;touch-action:pan-y}
+#card{width:80%;max-width:320px;height:220px;perspective:1000px;margin-bottom:1rem}
+#card-inner{position:relative;width:100%;height:100%;transform-style:preserve-3d;transition:transform .6s}
+.flipped #card-inner{transform:rotateY(180deg)}
+.face{position:absolute;top:0;left:0;width:100%;height:100%;border:2px solid #2196f3;border-radius:10px;background:#fff;display:flex;flex-direction:column;align-items:center;justify-content:center;backface-visibility:hidden}
 .front{font-size:4rem}
-.back{transform:rotateY(180deg);font-size:1.3rem;padding:.5rem;text-align:center}
+.back{transform:rotateY(180deg);font-size:1.2rem;padding:.5rem;text-align:center}
 nav{margin-top:1rem}
-button{padding:.5rem 1rem;margin:0 .5rem;font-size:1rem;border:none;border-radius:5px;background:#1e88e5;color:#fff}
+button{background:#2196f3;color:#fff;border:none;border-radius:5px;padding:.6rem 1rem;font-size:1rem;margin:0 .5rem;cursor:pointer}
+button:hover{background:#1976d2}
+button:active{background:#0d47a1}
+#progress{display:flex;margin-top:1rem}
+.dot{width:10px;height:10px;border:2px solid #2196f3;border-radius:50%;margin:0 3px}
+.filled{background:#2196f3}
+#counter{margin-top:.5rem;font-weight:bold}
+#complete{position:fixed;top:0;left:0;width:100%;height:100%;background:rgba(255,255,255,.9);display:none;flex-direction:column;align-items:center;justify-content:center;z-index:10}
+#complete.show{display:flex}
+#confetti{position:absolute;top:0;left:0;width:100%;height:100%;overflow:hidden;pointer-events:none}
+#confetti span{position:absolute;font-size:24px;animation:fall 3s linear infinite}
+@keyframes fall{from{transform:translateY(-10%)}to{transform:translateY(110%)}}
 </style>
 </head>
 <body>
-<div id="card">
-  <div class="inner">
+<div id="container">
+<div id="card" role="button" aria-label="Flip card">
+  <div id="card-inner">
     <div class="face front"></div>
     <div class="face back"></div>
   </div>
 </div>
 <nav>
-  <button id="prev">Prev</button>
-  <button id="next">Next</button>
+  <button id="prev" aria-label="Previous card">🔙 Prev</button>
+  <button id="next" aria-label="Next card">Next 🔜</button>
 </nav>
+<div id="progress"></div>
+<div id="counter"></div>
+</div>
+<div id="complete">
+  <div id="confetti"></div>
+  <button id="again" aria-label="Play again">Play again</button>
+</div>
 <script>
-const facts=[
-  '🚗 Cars once ran on steam.',
-  '💩 You can\'t hum while holding your nose.',
-  '🐸 Some frogs glow in the dark.',
-  '🍕 Pizza was first called "flatbread".',
-  '🚀 Astronauts grow taller in space.',
-  '🍦 Ice cream cones were invented by accident.',
-  '🦄 Unicorn is the national animal of Scotland.',
-  '🐌 A snail can sleep for three years.',
-  '🎩 Abraham Lincoln stored things in his hat.',
-  '🐒 Monkeys can learn sign language.'
+const deck=[
+ {num:1,word:'one',emoji:'\uD83D\uDCA9',fact:'Most toilets flush in E flat'},
+ {num:2,word:'two',emoji:'\uD83D\uDE80',fact:'Space smells like seared steak'},
+ {num:3,word:'three',emoji:'\uD83D\uDC38',fact:'Frogs drink through their skin'},
+ {num:4,word:'four',emoji:'\uD83D\uDE97',fact:'Cars were once powered by steam'},
+ {num:5,word:'five',emoji:'\uD83D\uDCA1',fact:'Thomas Edison feared the dark'},
+ {num:6,word:'six',emoji:'\uD83E\uDD84',fact:"Scotland's symbol is the unicorn"},
+ {num:7,word:'seven',emoji:'\uD83C\uDF89',fact:'Confetti was invented in Italy'},
+ {num:8,word:'eight',emoji:'\uD83D\uDD25',fact:'The Sun is 93m miles away'},
+ {num:9,word:'nine',emoji:'\uD83C\uDF88',fact:'Balloons were made from bladders'},
+ {num:10,word:'ten',emoji:'\uD83D\uDC51',fact:'A royal crown can weigh 3 pounds'}
 ];
+let cards=[...deck];
 let index=0;
+let answered=new Set();
 const card=document.getElementById('card');
-const inner=card.querySelector('.inner');
-const front=card.querySelector('.front');
-const back=card.querySelector('.back');
-function update(){front.textContent=index+1;back.textContent=facts[index];}
-function show(i){index=(i+facts.length)%facts.length;inner.style.transform='rotateY(0deg)';card.classList.remove('flip');update();}
-function flip(){card.classList.toggle('flip');}
-document.getElementById('prev').onclick=()=>show(index-1);
-document.getElementById('next').onclick=()=>show(index+1);
-card.addEventListener('click',flip);
+const cardInner=document.getElementById('card-inner');
+const front=document.querySelector('.front');
+const back=document.querySelector('.back');
+const progress=document.getElementById('progress');
+const counter=document.getElementById('counter');
+const complete=document.getElementById('complete');
+const again=document.getElementById('again');
+function shuffle(a){for(let i=a.length-1;i>0;i--){const j=Math.floor(Math.random()* (i+1));[a[i],a[j]]=[a[j],a[i]];}return a;}
+function buildProgress(){progress.innerHTML='';for(let i=0;i<deck.length;i++){const d=document.createElement('div');d.className='dot';progress.appendChild(d);}}
+function updateProgress(){progress.querySelectorAll('.dot').forEach((d,i)=>{d.classList.toggle('filled',answered.has(i+1));});counter.textContent='Cards left: '+(deck.length-answered.size);if(answered.size===deck.length)showComplete();}
+function showComplete(){complete.classList.add('show');createConfetti();}
+function hideComplete(){complete.classList.remove('show');document.getElementById('confetti').innerHTML='';}
+function createConfetti(){const c=document.getElementById('confetti');for(let i=0;i<40;i++){const s=document.createElement('span');s.textContent='🎊';s.style.left=Math.random()*100+'%';s.style.animationDelay=Math.random()*2+'s';c.appendChild(s);}}
+function loadCard(){const data=cards[index];front.textContent=data.num;back.innerHTML='<div style="font-size:2rem">'+data.word+' '+data.emoji+'</div><div>'+data.fact+'</div>';card.classList.remove('flipped');}
+function show(i){index=(i+cards.length)%cards.length;loadCard();}
+function flip(){const willShowBack=!card.classList.contains('flipped');card.classList.toggle('flipped');if(willShowBack){answered.add(cards[index].num);updateProgress();}}
+function restart(){cards=shuffle([...deck]);index=0;answered.clear();hideComplete();loadCard();updateProgress();}
 let startX=null;
-card.addEventListener('touchstart',e=>{startX=e.touches[0].clientX;});
-card.addEventListener('touchend',e=>{if(startX===null)return;const dx=e.changedTouches[0].clientX-startX;if(Math.abs(dx)>30){show(dx>0?index-1:index+1);}startX=null;});
-update();
+card.addEventListener('pointerdown',e=>{startX=e.clientX;});
+card.addEventListener('pointerup',e=>{if(startX===null)return;const dx=e.clientX-startX;if(Math.abs(dx)>30){show(dx<0?index+1:index-1);}else{flip();}startX=null;});
+document.getElementById('prev').addEventListener('click',()=>show(index-1));
+document.getElementById('next').addEventListener('click',()=>show(index+1));
+again.addEventListener('click',restart);
+buildProgress();restart();
 </script>
 </body>
 </html>


### PR DESCRIPTION
## Summary
- replace old flashcards app with a 10‑card deck
- add progress dots, card counter and confetti finish screen
- implement swipe navigation and card shuffling

## Testing
- `npm test` *(fails: could not find package.json)*

------
https://chatgpt.com/codex/tasks/task_e_68455a514e2c832a8b7e4c3c5751d32c